### PR TITLE
[10.0] [FIX] web_shortcut: QWeb render doesn't use string keys

### DIFF
--- a/web_shortcut/static/src/js/web_shortcut.js
+++ b/web_shortcut/static/src/js/web_shortcut.js
@@ -50,7 +50,7 @@ odoo.define('web.shortcut', function(require) {
         display: function(sc) {
             var self = this;
             this.$el.find('.oe_systray_shortcut_menu').append();
-            var $sc = $(qweb.render('Systray.ShortcutMenu.Item', {'shortcut': sc}));
+            var $sc = $(qweb.render('Systray.ShortcutMenu.Item', {shortcut: sc}));
             $sc.appendTo(self.$el.find('.oe_systray_shortcut_menu'));
         },
         remove: function (menu_id) {


### PR DESCRIPTION
This fixes a compatibility issue in Odoo 10 Enterprise
For https://github.com/OCA/web/pull/565